### PR TITLE
Upgrade to Angular 2.0.0-RC.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .idea
+node_modules/
+npm-debug.log

--- a/angular2-websocket.js
+++ b/angular2-websocket.js
@@ -1,3 +1,4 @@
+"use strict";
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
     if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
@@ -7,8 +8,8 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
 var __metadata = (this && this.__metadata) || function (k, v) {
     if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
 };
-var core_1 = require('angular2/core');
-var lang_1 = require('angular2/src/facade/lang');
+var core_1 = require('@angular/core');
+var lang_1 = require('@angular/compiler/src/facade/lang');
 var Subject_1 = require("rxjs/Subject");
 var $WebSocket = (function () {
     function $WebSocket(url, protocols, config) {
@@ -203,5 +204,5 @@ var $WebSocket = (function () {
         __metadata('design:paramtypes', [String, Array, Object])
     ], $WebSocket);
     return $WebSocket;
-})();
+}());
 exports.$WebSocket = $WebSocket;

--- a/angular2-websocket.ts
+++ b/angular2-websocket.ts
@@ -1,6 +1,6 @@
-import {Injectable} from 'angular2/core';
+import {Injectable} from '@angular/core';
 import {Observable} from "rxjs/Observable";
-import {isPresent, isString, isArray,isFunction} from 'angular2/src/facade/lang';
+import {isPresent, isString, isArray,isFunction} from '@angular/compiler/src/facade/lang';
 import {Scheduler} from "rxjs/Rx";
 import {Subject} from "rxjs/Subject";
 
@@ -228,4 +228,3 @@ export interface WebSocketConfig {
     maxTimeout:number ;
     reconnectIfNotNormalClose: boolean
 }
-

--- a/package.json
+++ b/package.json
@@ -10,11 +10,14 @@
     "url": "git+https://github.com/afrad/angular2-websocket.git"
   },
   "dependencies": {
-    "angular2": "^2.0.0-beta.0",
-    "es6-shim": "^0.33.3",
-    "reflect-metadata": "^0.1.2",
-    "rxjs": "^5.0.0-beta.0",
-    "zone.js": "^0.5.10"
+    "@angular/core":  "2.0.0-rc.1",
+    "@angular/common":  "2.0.0-rc.1",
+    "@angular/compiler":  "2.0.0-rc.1",
+
+    "es6-shim": "^0.35.0",
+    "reflect-metadata": "^0.1.3",
+    "rxjs": "5.0.0-beta.6",
+    "zone.js": "^0.6.12"
   },
   "devDependencies": {
     "grunt": "~0.4.1",


### PR DESCRIPTION
Yesterday RC.0 and today RC.1 was released. It would be nice if this cool repo could get upgraded to that. I tried it myself but getting issues that 'Map', 'Promise', 'Set', 'MapConstructor', and 'SetConstructor' could not be found on compile.

Maybe someone can help with that? Would be happy to get it working soon.