### PR TITLE
Switching shim from es6-shim to core-js.  I changed the typings scrip…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "angular2-websocket",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "compile": "tsc",
-    "typings": "typings install es6-shim --ambient"
+    "typings": "typings install"
   },
   "repository": {
     "type": "git",
@@ -14,16 +14,16 @@
     "@angular/common": "2.0.0-rc.1",
     "@angular/compiler": "2.0.0-rc.1",
     "@angular/core": "2.0.0-rc.1",
-    "es6-shim": "^0.35.0",
+    "core-js": "^2.4.0",
     "reflect-metadata": "^0.1.3",
     "rxjs": "5.0.0-beta.6",
     "zone.js": "^0.6.12"
   },
   "devDependencies": {
     "grunt": "~0.4.1",
-    "grunt-typescript": "~0.2.4",
     "grunt-contrib-uglify": "~0.2.4",
-    "typings": "^0.8.1",
-    "typescript": "^1.7.5"
+    "grunt-typescript": "~0.2.4",
+    "typescript": "^1.7.5",
+    "typings": "^1.3.1"
   }
 }

--- a/typings.json
+++ b/typings.json
@@ -1,5 +1,5 @@
 {
-  "ambientDevDependencies": {
-    "es6-shim": "registry:dt/es6-shim#0.31.2+20160317120654"
+  "globalDependencies": {
+    "core-js": "registry:dt/core-js#0.0.0+20160602141332"
   }
 }


### PR DESCRIPTION
…t so that it simply calls install instead of directly installing es6-shim's typings.  I've added the core-js typings to typings.json as well.  Confirmed that compile works properly with core-js in place.  I also updated the version of typings being used from 0.8.1 to 1.3.1.  Bumped the version to 0.6.4 to reflect the change.
