### PR TITLE
Update angular2-websocket.js

### DIFF
--- a/angular2-websocket.js
+++ b/angular2-websocket.js
@@ -98,7 +98,7 @@ var $WebSocket = (function () {
     $WebSocket.prototype.fireQueue = function () {
         while (this.sendQueue.length && this.socket.readyState === this.readyStateConstants.OPEN) {
             var data = this.sendQueue.shift();
-            this.socket.send(lang_1.isString(data.message) ? data.message : JSON.stringify(data.message));
+            this.socket.send(data.message);
         }
     };
     $WebSocket.prototype.notifyCloseCallbacks = function (event) {


### PR DESCRIPTION
dont jsonify sended data.

I think is important and necessary allow users send data in any type, in my case i'm using protobuf as bitearray, and the wrapper was converting the bytearray to json.