### PR TITLE
Allow websocket send any type of data

### DIFF
--- a/angular2-websocket.js
+++ b/angular2-websocket.js
@@ -98,7 +98,7 @@ var $WebSocket = (function () {
     $WebSocket.prototype.fireQueue = function () {
         while (this.sendQueue.length && this.socket.readyState === this.readyStateConstants.OPEN) {
             var data = this.sendQueue.shift();
-            this.socket.send(lang_1.isString(data.message) ? data.message : JSON.stringify(data.message));
+            this.socket.send(data.message);
         }
     };
     $WebSocket.prototype.notifyCloseCallbacks = function (event) {

--- a/src/angular2-websocket.ts
+++ b/src/angular2-websocket.ts
@@ -98,9 +98,7 @@ export class $WebSocket  {
         while (this.sendQueue.length && this.socket.readyState === this.readyStateConstants.OPEN) {
             var data = this.sendQueue.shift();
 
-            this.socket.send(
-                isString(data.message) ? data.message : JSON.stringify(data.message)
-            );
+            this.socket.send(data.message);
             // data.deferred.resolve();
         }
     }


### PR DESCRIPTION
i think is user responsibility encode the message, and the library must just send the user's data. this approach is better because allow use websockets with other protocols like "protobuf".