### PR TITLE
Update typings and packages to use core-js 2.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "compile": "tsc",
-    "typings": "typings install es6-shim --ambient"
+    "typings": "typings install"
   },
   "repository": {
     "type": "git",
@@ -14,7 +14,7 @@
     "@angular/common": "2.0.0-rc.4",
     "@angular/compiler": "2.0.0-rc.4",
     "@angular/core": "2.0.0-rc.4",
-    "es6-shim": "^0.35.0",
+    "core-js": "^2.4.1",
     "reflect-metadata": "^0.1.3",
     "rxjs": "5.0.0-beta.6",
     "zone.js": "^0.6.12"
@@ -23,7 +23,7 @@
     "grunt": "~0.4.1",
     "grunt-typescript": "~0.2.4",
     "grunt-contrib-uglify": "~0.2.4",
-    "typings": "^0.8.1",
-    "typescript": "^1.7.5"
+    "typings": "^1.3.2",
+    "typescript": "^1.8.10"
   }
 }

--- a/typings.json
+++ b/typings.json
@@ -1,5 +1,5 @@
 {
-  "ambientDevDependencies": {
-    "es6-shim": "registry:dt/es6-shim#0.31.2+20160317120654"
+  "globalDependencies": {
+    "core-js": "registry:dt/core-js#0.0.0+20160602141332"
   }
 }


### PR DESCRIPTION
The old pull request for this referenced older packages and had merge conflicts with the current master. This one does not.