### PR TITLE
Fix the wrong return type for connect() and send()

### DIFF
--- a/angular2-websocket.d.ts
+++ b/angular2-websocket.d.ts
@@ -21,7 +21,7 @@ export declare class $WebSocket {
     private socket;
     private internalConnectionState;
     constructor(url: string, protocols?: Array<string>, config?: WebSocketConfig);
-    connect(force?: boolean): Observable<{}>;
+    connect(force?: boolean): void;
     static create(url: string, protocols: Array<string>): WebSocket;
     onOpenHandler(event: Event): void;
     notifyOpenCallbacks(event: any): void;
@@ -35,7 +35,7 @@ export declare class $WebSocket {
     onMessageHandler(message: MessageEvent): void;
     onCloseHandler(event: CloseEvent): void;
     onErrorHandler(event: any): void;
-    send(data: any): Observable<{}>;
+    send(data: any): Observable<any>;
     reconnect(): this;
     close(force: boolean): this;
     getBackoffDelay(attempt: any): number;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "compile": "tsc",
-    "typings": "typings install"
+    "typings": "typings install",
+    "lint": "tslint \"src/**/*.ts\""
   },
   "repository": {
     "type": "git",
@@ -21,9 +22,11 @@
     "zone.js": "^0.6.12"
   },
   "devDependencies": {
+    "codelyzer": "~0.0.26",
     "grunt": "~0.4.1",
     "grunt-typescript": "~0.2.4",
     "grunt-contrib-uglify": "~0.2.4",
+    "tslint": "3.13.0",
     "typings": "^1.3.2",
     "typescript": "^1.8.10"
   }

--- a/src/angular2-websocket.ts
+++ b/src/angular2-websocket.ts
@@ -1,11 +1,10 @@
 import {Injectable} from '@angular/core';
-import {Observable} from "rxjs/Observable";
-import {Scheduler} from "rxjs/Rx";
-import {Subject} from "rxjs/Subject";
+import {Observable} from 'rxjs/Observable';
+import {Subject} from 'rxjs/Subject';
 
 
 @Injectable()
-export class $WebSocket  {
+export class $WebSocket {
 
     private reconnectAttempts = 0;
     private sendQueue = [];
@@ -20,27 +19,27 @@ export class $WebSocket  {
         'CLOSED': 3,
         'RECONNECT_ABORTED': 4
     };
-    private  normalCloseCode = 1000;
-    private  reconnectableStatusCodes = [4000];
+    private normalCloseCode = 1000;
+    private reconnectableStatusCodes = [4000];
     private socket: WebSocket;
     private dataStream: Subject<any>;
-    private  internalConnectionState: number;
-    constructor(private url:string, private protocols?:Array<string>, private config?: WebSocketConfig  ) {
-        var match = new RegExp('wss?:\/\/').test(url);
+    private internalConnectionState: number;
+    constructor(private url: string, private protocols?: Array<string>, private config?: WebSocketConfig) {
+        let match = new RegExp('wss?:\/\/').test(url);
         if (!match) {
             throw new Error('Invalid url provided');
         }
-        this.config = config ||{ initialTimeout: 500, maxTimeout : 300000, reconnectIfNotNormalClose :false};
+        this.config = config || { initialTimeout: 500, maxTimeout: 300000, reconnectIfNotNormalClose: false };
         this.dataStream = new Subject();
     }
 
-    connect(force:boolean = false) {
-        var self = this;
+    connect(force = false) {
+        let self = this;
         if (force || !this.socket || this.socket.readyState !== this.readyStateConstants.OPEN) {
-            self.socket =this.protocols ? new WebSocket(this.url, this.protocols) : new WebSocket(this.url);
+            self.socket = this.protocols ? new WebSocket(this.url, this.protocols) : new WebSocket(this.url);
 
-            self.socket.onopen =(ev: Event) => {
-            //    console.log('onOpen: %s', ev);
+            self.socket.onopen = (ev: Event) => {
+                //    console.log('onOpen: %s', ev);
                 this.onOpenHandler(ev);
             };
             self.socket.onmessage = (ev: MessageEvent) => {
@@ -62,23 +61,22 @@ export class $WebSocket  {
         }
     }
     send(data) {
-        var self = this;
-        if (this.getReadyState() != this.readyStateConstants.OPEN &&this.getReadyState() != this.readyStateConstants.CONNECTING ){
+        let self = this;
+        if (this.getReadyState() !== this.readyStateConstants.OPEN
+                && this.getReadyState() !== this.readyStateConstants.CONNECTING) {
             this.connect();
         }
         return Observable.create((observer) => {
             if (self.socket.readyState === self.readyStateConstants.RECONNECT_ABORTED) {
                 observer.next('Socket connection has been closed');
-            }
-            else {
-                self.sendQueue.push({message: data});
+            } else {
+                self.sendQueue.push({ message: data });
                 self.fireQueue();
             }
-
         });
     };
 
-    getDataStream():Subject<any>{
+    getDataStream(): Subject<any> {
         return this.dataStream;
     }
 
@@ -94,7 +92,7 @@ export class $WebSocket  {
     }
     fireQueue() {
         while (this.sendQueue.length && this.socket.readyState === this.readyStateConstants.OPEN) {
-            var data = this.sendQueue.shift();
+            let data = this.sendQueue.shift();
 
             this.socket.send(
                 $WebSocket.Helpers.isString(data.message) ? data.message : JSON.stringify(data.message)
@@ -110,7 +108,7 @@ export class $WebSocket  {
     }
 
     notifyErrorCallbacks(event) {
-        for (var i = 0; i < this.onErrorCallbacks.length; i++) {
+        for (let i = 0; i < this.onErrorCallbacks.length; i++) {
             this.onErrorCallbacks[i].call(this, event);
         }
     }
@@ -145,18 +143,17 @@ export class $WebSocket  {
     }
 
     onMessageHandler(message: MessageEvent) {
-        var pattern;
-        var self = this;
-        var currentCallback;
-        for (var i = 0; i < self.onMessageCallbacks.length; i++) {
+        let self = this;
+        let currentCallback;
+        for (let i = 0; i < self.onMessageCallbacks.length; i++) {
             currentCallback = self.onMessageCallbacks[i];
             currentCallback.fn.apply(self, [message]);
         }
-
     };
     onCloseHandler(event: CloseEvent) {
         this.notifyCloseCallbacks(event);
-        if ((this.config.reconnectIfNotNormalClose && event.code !== this.normalCloseCode) || this.reconnectableStatusCodes.indexOf(event.code) > -1) {
+        if ((this.config.reconnectIfNotNormalClose && event.code !== this.normalCloseCode)
+                || this.reconnectableStatusCodes.indexOf(event.code) > -1) {
             this.reconnect();
         } else {
             this.dataStream.complete();
@@ -173,10 +170,10 @@ export class $WebSocket  {
 
     reconnect() {
         this.close(true);
-        var backoffDelay = this.getBackoffDelay(++this.reconnectAttempts);
-        var backoffDelaySeconds = backoffDelay / 1000;
+        let backoffDelay = this.getBackoffDelay(++this.reconnectAttempts);
+        // let backoffDelaySeconds = backoffDelay / 1000;
         // console.log('Reconnecting in ' + backoffDelaySeconds + ' seconds');
-        setTimeout( this.connect(), backoffDelay);
+        setTimeout(this.connect(), backoffDelay);
         return this;
     }
 
@@ -189,11 +186,11 @@ export class $WebSocket  {
     // Exponential Backoff Formula by Prof. Douglas Thain
     // http://dthain.blogspot.co.uk/2009/02/exponential-backoff-in-distributed.html
     getBackoffDelay(attempt) {
-        var R = Math.random() + 1;
-        var T = this.config.initialTimeout;
-        var F = 2;
-        var N = attempt;
-        var M = this.config.maxTimeout;
+        let R = Math.random() + 1;
+        let T = this.config.initialTimeout;
+        let F = 2;
+        let N = attempt;
+        let M = this.config.maxTimeout;
 
         return Math.floor(Math.min(R * T * Math.pow(F, N), M));
     };
@@ -212,8 +209,7 @@ export class $WebSocket  {
      * @returns {number}
      */
     getReadyState() {
-        if (this.socket == null)
-        {
+        if (this.socket == null) {
             return -1;
         }
         return this.internalConnectionState || this.socket.readyState;
@@ -225,7 +221,7 @@ export class $WebSocket  {
         }
 
         static isString(obj: any): boolean {
-            return typeof obj === "string";
+            return typeof obj === 'string';
         }
 
         static isArray(obj: any): boolean {
@@ -233,14 +229,14 @@ export class $WebSocket  {
         }
 
         static isFunction(obj: any): boolean {
-            return typeof obj === "function";
+            return typeof obj === 'function';
         }
-    }
+    };
 }
 
 export interface WebSocketConfig {
-    initialTimeout:number;
-    maxTimeout:number ;
-    reconnectIfNotNormalClose: boolean
+    initialTimeout: number;
+    maxTimeout: number;
+    reconnectIfNotNormalClose: boolean;
 }
 

--- a/src/angular2-websocket.ts
+++ b/src/angular2-websocket.ts
@@ -6,6 +6,24 @@ import {Subject} from 'rxjs/Subject';
 @Injectable()
 export class $WebSocket {
 
+    private static Helpers = class {
+        static isPresent(obj: any): boolean {
+            return obj !== undefined && obj !== null;
+        }
+
+        static isString(obj: any): boolean {
+            return typeof obj === 'string';
+        }
+
+        static isArray(obj: any): boolean {
+            return Array.isArray(obj);
+        }
+
+        static isFunction(obj: any): boolean {
+            return typeof obj === 'function';
+        }
+    };
+
     private reconnectAttempts = 0;
     private sendQueue = [];
     private onOpenCallbacks = [];
@@ -60,7 +78,7 @@ export class $WebSocket {
 
         }
     }
-    send(data) {
+    send(data): Observable<any> {
         let self = this;
         if (this.getReadyState() !== this.readyStateConstants.OPEN
                 && this.getReadyState() !== this.readyStateConstants.CONNECTING) {
@@ -214,24 +232,6 @@ export class $WebSocket {
         }
         return this.internalConnectionState || this.socket.readyState;
     }
-
-    private static Helpers = class {
-        static isPresent(obj: any): boolean {
-            return obj !== undefined && obj !== null;
-        }
-
-        static isString(obj: any): boolean {
-            return typeof obj === 'string';
-        }
-
-        static isArray(obj: any): boolean {
-            return Array.isArray(obj);
-        }
-
-        static isFunction(obj: any): boolean {
-            return typeof obj === 'function';
-        }
-    };
 }
 
 export interface WebSocketConfig {

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,125 @@
+{
+  "rulesDirectory": [
+    "node_modules/codelyzer"
+  ],
+  "rules": {
+    "class-name": true,
+    "comment-format": [
+      true,
+      "check-space"
+    ],
+    "curly": true,
+    "eofline": true,
+    "forin": true,
+    "indent": [
+      true,
+      "spaces"
+    ],
+    "label-position": true,
+    "label-undefined": true,
+    "max-line-length": [
+      true,
+      140
+    ],
+    "member-access": false,
+    "member-ordering": [
+      true,
+      {
+        "order": [
+          "static-before-instance",
+          "variables-before-functions"
+        ]
+      }
+    ],
+    "no-arg": true,
+    "no-bitwise": true,
+    "no-console": [
+      true,
+      "debug",
+      "info",
+      "time",
+      "timeEnd",
+      "trace"
+    ],
+    "no-construct": true,
+    "no-debugger": true,
+    "no-duplicate-key": true,
+    "no-duplicate-variable": true,
+    "no-empty": false,
+    "no-eval": true,
+    "no-inferrable-types": true,
+    "no-shadowed-variable": true,
+    "no-string-literal": false,
+    "no-switch-case-fall-through": true,
+    "no-trailing-whitespace": true,
+    "no-unused-expression": true,
+    "no-unused-variable": true,
+    "no-unreachable": true,
+    "no-use-before-declare": true,
+    "no-var-keyword": true,
+    "object-literal-sort-keys": false,
+    "one-line": [
+      true,
+      "check-open-brace",
+      "check-catch",
+      "check-else",
+      "check-whitespace"
+    ],
+    "quotemark": [
+      true,
+      "single"
+    ],
+    "radix": true,
+    "semicolon": [
+      "always"
+    ],
+    "triple-equals": [
+      true,
+      "allow-null-check"
+    ],
+    "typedef-whitespace": [
+      true,
+      {
+        "call-signature": "nospace",
+        "index-signature": "nospace",
+        "parameter": "nospace",
+        "property-declaration": "nospace",
+        "variable-declaration": "nospace"
+      }
+    ],
+    "variable-name": false,
+    "whitespace": [
+      true,
+      "check-branch",
+      "check-decl",
+      "check-operator",
+      "check-separator",
+      "check-type"
+    ],
+    "directive-selector-name": [
+      true,
+      "camelCase"
+    ],
+    "component-selector-name": [
+      true,
+      "kebab-case"
+    ],
+    "directive-selector-type": [
+      true,
+      "attribute"
+    ],
+    "component-selector-type": [
+      true,
+      "element"
+    ],
+    "use-input-property-decorator": true,
+    "use-output-property-decorator": true,
+    "use-host-property-decorator": true,
+    "no-input-rename": true,
+    "no-output-rename": true,
+    "use-life-cycle-interface": true,
+    "use-pipe-transform-interface": true,
+    "component-class-suffix": true,
+    "directive-class-suffix": true
+  }
+}

--- a/tslint.json
+++ b/tslint.json
@@ -25,10 +25,7 @@
     "member-ordering": [
       true,
       {
-        "order": [
-          "static-before-instance",
-          "variables-before-functions"
-        ]
+        "order": "fields-first"
       }
     ],
     "no-arg": true,


### PR DESCRIPTION
The `connect()` and `send()` method have not defined with the correct type in `angular2-websocket.d.ts`. This PR fix it. 
The return type for `send()` has also been added to `angular2-websocket.ts`.

The PR also integrates `tslint` with the project: call `npm run lint` to see errors.