### PR TITLE
Connect method call from setTimeout fixed

### DIFF
--- a/src/angular2-websocket.ts
+++ b/src/angular2-websocket.ts
@@ -191,7 +191,7 @@ export class $WebSocket {
         let backoffDelay = this.getBackoffDelay(++this.reconnectAttempts);
         // let backoffDelaySeconds = backoffDelay / 1000;
         // console.log('Reconnecting in ' + backoffDelaySeconds + ' seconds');
-        setTimeout(this.connect(), backoffDelay);
+        setTimeout(() => this.connect(), backoffDelay);
         return this;
     }
 


### PR DESCRIPTION
First argument of `setTimeout` method must be a function, not a result of execution.