### PR TITLE
Allow to set binaryType on for Websocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,6 @@ npm run compile
 
 ```
 
-## Configuration
-The `WebSocketConfig` takes the following options:
-
-* initialTimeout: number;
-* maxTimeout: number;
-* reconnectIfNotNormalClose: boolean;
-* binaryType: string;
 
 The default value for binary type is 'arrayBuffer'.
 
@@ -115,4 +108,14 @@ ws.close(false);    // close
 ws.close(true);    // close immediately
 
 
+```
+
+## Binary type
+To set the binary type for the websocket one can provide it as string in the constructor. Allowed types are:
+
+* 'blob' (default)
+* 'arraybuffer'
+
+```ts
+var ws = new $WebSocket("ws://127.0.0.1:7000", null, null, 'arraybuffer');
 ```

--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ npm run compile
 
 ```
 
+## Configuration
+The `WebSocketConfig` takes the following options:
+
+* initialTimeout: number;
+* maxTimeout: number;
+* reconnectIfNotNormalClose: boolean;
+* binaryType: string;
+
+The default value for binary type is 'arrayBuffer'.
+
 ## example
 ```ts
 import {$WebSocket, WebSocketSendMode} from 'angular2-websocket/angular2-websocket';

--- a/src/angular2-websocket.ts
+++ b/src/angular2-websocket.ts
@@ -42,12 +42,13 @@ export class $WebSocket {
     private dataStream: Subject<any>;
     private internalConnectionState: number;
 
-    constructor(private url: string, private protocols?: Array<string>, private config?: WebSocketConfig) {
+    constructor(private url: string, private protocols?: Array<string>, private config?: WebSocketConfig, private binaryType?: BinaryType) {
         let match = new RegExp('wss?:\/\/').test(url);
         if (!match) {
             throw new Error('Invalid url provided');
         }
-        this.config = config || {initialTimeout: 500, maxTimeout: 300000, reconnectIfNotNormalClose: false, binaryType: 'arraybuffer'};
+        this.config = config || {initialTimeout: 500, maxTimeout: 300000, reconnectIfNotNormalClose: false};
+        this.binaryType = binaryType || "blob";
         this.dataStream = new Subject();
         this.connect(true);
     }
@@ -57,7 +58,7 @@ export class $WebSocket {
         let self = this;
         if (force || !this.socket || this.socket.readyState !== this.readyStateConstants.OPEN) {
             self.socket = this.protocols ? new WebSocket(this.url, this.protocols) : new WebSocket(this.url);
-            self.socket.binaryType = self.config.binaryType;
+            self.socket.binaryType = self.binaryType.toString();
 
             self.socket.onopen = (ev: Event) => {
                 // console.log('onOpen: ', ev);
@@ -315,10 +316,11 @@ export interface WebSocketConfig {
     initialTimeout: number;
     maxTimeout: number;
     reconnectIfNotNormalClose: boolean;
-    binaryType: string;
 }
 
 export enum WebSocketSendMode {
     Direct, Promise, Observable
 }
+
+export type BinaryType = "blob" | "arraybuffer";
 

--- a/src/angular2-websocket.ts
+++ b/src/angular2-websocket.ts
@@ -47,7 +47,7 @@ export class $WebSocket {
         if (!match) {
             throw new Error('Invalid url provided');
         }
-        this.config = config || {initialTimeout: 500, maxTimeout: 300000, reconnectIfNotNormalClose: false};
+        this.config = config || {initialTimeout: 500, maxTimeout: 300000, reconnectIfNotNormalClose: false, binaryType: 'arraybuffer'};
         this.dataStream = new Subject();
         this.connect(true);
     }
@@ -57,6 +57,7 @@ export class $WebSocket {
         let self = this;
         if (force || !this.socket || this.socket.readyState !== this.readyStateConstants.OPEN) {
             self.socket = this.protocols ? new WebSocket(this.url, this.protocols) : new WebSocket(this.url);
+            self.socket.binaryType = self.config.binaryType;
 
             self.socket.onopen = (ev: Event) => {
                 // console.log('onOpen: ', ev);
@@ -314,6 +315,7 @@ export interface WebSocketConfig {
     initialTimeout: number;
     maxTimeout: number;
     reconnectIfNotNormalClose: boolean;
+    binaryType: string;
 }
 
 export enum WebSocketSendMode {


### PR DESCRIPTION
The problem in my case was that I needed arraybuffer for the binary data. But the option to set it on the underlying websocket was not available.