### PR TITLE
interrupt reConnect if websocket is closed

### DIFF
--- a/src/angular2-websocket.ts
+++ b/src/angular2-websocket.ts
@@ -275,15 +275,23 @@ export class $WebSocket {
     };
 
     reconnect() {
-        this.close(true);
+        this.close(true, true);
         let backoffDelay = this.getBackoffDelay(++this.reconnectAttempts);
         // let backoffDelaySeconds = backoffDelay / 1000;
         // console.log('Reconnecting in ' + backoffDelaySeconds + ' seconds');
-        setTimeout(() => this.connect(), backoffDelay);
+        setTimeout(() => {
+            if (this.config.reconnectIfNotNormalClose) {
+                this.connect()
+            }
+        }, backoffDelay);
         return this;
     }
 
-    close(force: boolean = false) {
+    close(force: boolean = false, keepReconnectIfNotNormalClose?: boolean) {
+        if (!keepReconnectIfNotNormalClose) {
+            this.config.reconnectIfNotNormalClose = false;
+        }
+
         if (force || !this.socket.bufferedAmount) {
             this.socket.close(this.normalCloseCode);
         }
@@ -334,4 +342,3 @@ export enum WebSocketSendMode {
 }
 
 export type BinaryType = "blob" | "arraybuffer";
-


### PR DESCRIPTION
If the websocket is interrupted and we reconnect it trought reconnectIfNotNormalClose parameter, after closing the websocket manually in the background the setTimout and the reconnecting logic is always present and it tries to reconnect it to websocket.

This change is setting on manually close method the reconnectIfNotNormalClose to false and the timeout logic is handling the status of the paramter.